### PR TITLE
break inherithance SusyNtAna : SusyNtTools

### DIFF
--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -63,6 +63,13 @@ JetSelector JetSelector::build_WH_analysis_selector(JVFUncertaintyTool* const t,
         ;
 }
 //----------------------------------------------------------
+JVFUncertaintyTool* JetSelector::build_jvf_tool()
+{
+  JVFUncertaintyTool *jvfTool = new JVFUncertaintyTool();
+  jvfTool->UseGeV(true);
+  return jvfTool;
+}
+//----------------------------------------------------------
 bool JetSelector::isSignalJet(const Jet* jet)
 {
   // For now, 2lep analysis is not using this jet definition

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -3,6 +3,7 @@
 
 #include "JVFUncertaintyTool/JVFUncertaintyTool.h"
 
+#include <algorithm>
 #include <cassert>
 #include <iostream>
 
@@ -126,7 +127,7 @@ bool JetSelector::isCentralBJet(const Jet* jet)
 bool JetSelector::isForwardJet(const Jet* jet)
 {
   if(jet->Pt() < JET_PT_F30_CUT         ) return false;
-  if(fabs(jet->detEta) < JET_ETA_CUT_2L  ) return false; 
+  if(fabs(jet->detEta) < JET_ETA_CUT_2L  ) return false;
   if(fabs(jet->detEta) > JET_ETA_MAX_CUT ) return false;
   return true;
 }
@@ -144,15 +145,14 @@ bool JetSelector::hasJetInBadFCAL(const JetVector& baseJets, uint run, bool isMC
 //----------------------------------------------------------
 bool JetSelector::isBadFCALJet(const Jet* jet)
 {
-  if(jet->Pt() > BAD_FCAL_PT  && 
+  if(jet->Pt() > BAD_FCAL_PT  &&
      fabs(jet->Eta()) > BAD_FCAL_ETA &&
-     jet->Phi() > BAD_FCAL_PHILOW && 
+     jet->Phi() > BAD_FCAL_PHILOW &&
      jet->Phi() < BAD_FCAL_PHIHIGH)
     return true;
   return false;
 }
 //----------------------------------------------------------
-
 bool JetSelector::jetPassesJvfRequirement(const Jet* jet, float maxPt, float maxEta, float nominalJvtThres)
 {
     bool pass=false;
@@ -184,4 +184,19 @@ bool JetSelector::jetPassesJvfRequirement(const Jet* jet, float maxPt, float max
     return pass;
 }
 //----------------------------------------------------------
-
+size_t JetSelector::count_CL_jets(const JetVector &jets)
+{
+    return std::count_if(jets.begin(), jets.end(),
+                         std::bind1st(std::mem_fun(&JetSelector::isCentralLightJet), this));
+}
+//----------------------------------------------------------
+size_t JetSelector::count_CB_jets(const JetVector &jets)
+{
+    return std::count_if(jets.begin(), jets.end(), JetSelector::isCentralBJet);
+}
+//----------------------------------------------------------
+size_t JetSelector::count_F_jets(const JetVector &jets)
+{
+    return std::count_if(jets.begin(), jets.end(), JetSelector::isForwardJet);
+}
+//----------------------------------------------------------

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -1,0 +1,180 @@
+#include "SusyNtuple/JetSelector.h"
+#include "SusyNtuple/SusyNt.h"
+
+#include "JVFUncertaintyTool/JVFUncertaintyTool.h"
+
+#include <cassert>
+#include <iostream>
+
+using Susy::JetSelector;
+using Susy::Jet;
+using std::cout;
+using std::endl;
+
+
+//----------------------------------------------------------
+JetSelector::JetSelector(JVFUncertaintyTool* const jvftool,
+                         const SusyNtSys& systematic,
+                         const AnalysisType& analysis):
+/*
+  \todo: these will be used internally when refactoring
+    m_skip_pt(true),
+    m_skip_eta(true),
+    m_skip_jvf(true),
+    m_min_pt(0.0),
+    m_max_eta(0.0),
+    m_max_jvf_eta(0.0),
+    m_min_jvf(0.0),
+*/
+    m_jvftool(jvftool),
+    m_systematic(systematic),
+    m_analysis(analysis),
+    m_verbose(false)
+{
+}
+//----------------------------------------------------------
+JetSelector JetSelector::build_2L_analysis_selector(JVFUncertaintyTool* const t,
+                                                    const SusyNtSys &s,
+                                                    const AnalysisType &a)
+{
+    return JetSelector(t, s, a)
+        // .requireMinPt(20.0)
+        // .requireMaxEta(2.5)
+        ;
+}
+//----------------------------------------------------------
+JetSelector JetSelector::build_3L_analysis_selector(JVFUncertaintyTool* const t,
+                                                    const SusyNtSys &s,
+                                                    const AnalysisType &a)
+{
+    return JetSelector(t, s, a)
+        // .requireMinPt(20.0)
+        // .requireMaxEta(2.5)
+        ;
+}
+//----------------------------------------------------------
+JetSelector JetSelector::build_WH_analysis_selector(JVFUncertaintyTool* const t,
+                                                    const SusyNtSys &s,
+                                                    const AnalysisType &a)
+{
+    return JetSelector(t, s, a)
+        // .requireMinPt(20.0)
+        // .requireMaxEta(2.5)
+        ;
+}
+//----------------------------------------------------------
+bool JetSelector::isSignalJet(const Jet* jet)
+{
+  // For now, 2lep analysis is not using this jet definition
+  //float ptCut = m_anaType==Ana_2Lep? JET_SIGNAL_PT_CUT_2L : JET_SIGNAL_PT_CUT_3L;
+    bool pass = false;
+    if(jet) {
+        float ptCut = JET_SIGNAL_PT_CUT_3L;
+        pass = (jet->Pt() > ptCut
+                && fabs(jet->Eta()) < JET_ETA_CUT
+                && jetPassesJvfRequirement(jet, JET_JVF_PT, JET_JVF_ETA, JET_JVF_CUT));
+    } else {
+        cout << "isSignalJet: invalid jet(" << jet << "), return " << pass << endl;
+    }
+    return pass;
+}
+//----------------------------------------------------------
+bool JetSelector::isSignalJet2Lep(const Jet* jet)
+{
+    return (isCentralLightJet(jet)
+            || isCentralBJet(jet)
+            || isForwardJet(jet));
+}
+//----------------------------------------------------------
+bool JetSelector::isCentralLightJet(const Jet* jet)
+{
+    // This function is mostly used by the 2L analyses. Needs to be reorganized...
+    bool pass = false;
+    if(jet) {
+        float minJvf = JET_JVF_CUT;
+        float maxJvtEta = JET_JVF_ETA;
+        if(m_analysis == Ana_2Lep || m_analysis == Ana_2LepWH) {
+            minJvf = JET_JVF_CUT_2L;
+            maxJvtEta = JET_ETA_CUT_2L;
+        }
+        pass = (jet->Pt() > JET_PT_L20_CUT
+                && fabs(jet->detEta) < JET_ETA_CUT_2L
+                && jet->mv1 < MV1_80
+                && JetSelector::jetPassesJvfRequirement(jet, JET_JVF_PT, maxJvtEta, minJvf));
+    } else {
+        cout << "isCentralLightJet: invalid jet(" << jet << "), return " << pass << endl;
+    }
+    return pass;
+}
+//----------------------------------------------------------
+bool JetSelector::isCentralBJet(const Jet* jet)
+{
+  if(jet->Pt() < JET_PT_B20_CUT) return false;
+  if(fabs(jet->detEta) > JET_ETA_CUT_2L) return false;
+  if(jet->mv1 < MV1_80) return false;
+
+  return true;
+}
+//----------------------------------------------------------
+bool JetSelector::isForwardJet(const Jet* jet)
+{
+  if(jet->Pt() < JET_PT_F30_CUT         ) return false;
+  if(fabs(jet->detEta) < JET_ETA_CUT_2L  ) return false; 
+  if(fabs(jet->detEta) > JET_ETA_MAX_CUT ) return false;
+  return true;
+}
+//----------------------------------------------------------
+bool JetSelector::hasJetInBadFCAL(const JetVector& baseJets, uint run, bool isMC)
+{
+  // Only applied to data in periods C1 to C8
+    if(isMC || run<206248 || run>207332) return false; // refactor this DG
+  for(uint iJ=0; iJ<baseJets.size(); ++iJ){
+    const Jet* j = baseJets.at(iJ);
+    if(isBadFCALJet(j)) return true;
+  }
+  return false;
+}
+//----------------------------------------------------------
+bool JetSelector::isBadFCALJet(const Jet* jet)
+{
+  if(jet->Pt() > BAD_FCAL_PT  && 
+     fabs(jet->Eta()) > BAD_FCAL_ETA &&
+     jet->Phi() > BAD_FCAL_PHILOW && 
+     jet->Phi() < BAD_FCAL_PHIHIGH)
+    return true;
+  return false;
+}
+//----------------------------------------------------------
+
+bool JetSelector::jetPassesJvfRequirement(const Jet* jet, float maxPt, float maxEta, float nominalJvtThres)
+{
+    bool pass=false;
+    if(jet) {
+        float pt(jet->Pt()), eta(jet->detEta);
+        float jvfThres(nominalJvtThres);
+        bool applyJvf(pt < maxPt && fabs(eta) < maxEta);
+        bool jvfUp(m_systematic == NtSys_JVF_UP), jvfDown(m_systematic == NtSys_JVF_DN);
+        if(jvfUp || jvfDown) {
+            if(m_jvftool) {
+                bool isPileUp = false; // Twiki [add link here] says to treat all jets as hardscatter
+                jvfThres = m_jvftool->getJVFcut(nominalJvtThres, isPileUp, pt, eta, jvfUp);
+            } else {
+                cout<<"jetPassesJvfRequirement: error, jvfTool required ("<<m_jvftool<<")"<<endl;
+                assert(m_jvftool);
+            }
+        }
+        bool acceptMinusOne(m_analysis==Ana_2Lep);  // Ana_2Lep accepts jvf of -1 (corresponds to jet w/out tracks)
+        bool jvfIsMinusOne(fabs(jet->jvf + 1.0) < 1e-3);
+        if(applyJvf) {
+            pass = (jet->jvf > jvfThres || (acceptMinusOne && jvfIsMinusOne));
+        } else {
+            pass = true;
+        }
+    } else {
+        cout<<"jetPassesJvfRequirement: invalid inputs jet("<<jet<<"), jvfTool("<<m_jvftool<<")."
+            <<"Return " << pass << endl;
+    }
+    return pass;
+}
+//----------------------------------------------------------
+

--- a/Root/Susy2LepCutflow.cxx
+++ b/Root/Susy2LepCutflow.cxx
@@ -63,7 +63,7 @@ Susy2LepCutflow::Susy2LepCutflow() :
 
   //out.open("event.dump");
   
-  setAnaType(Ana_2Lep);
+  m_nttools.setAnaType(Ana_2Lep);
 
 }
 
@@ -150,13 +150,13 @@ bool Susy2LepCutflow::selectEvent(const LeptonVector& leptons, const LeptonVecto
   //int flag = nt.evt()->evtFlag[NtSys_NOM];
   int flag = nt.evt()->cutFlags[NtSys_NOM];
 
-  if( !passLAr(flag) )              return false;
+  if( !SusyNtTools::passLAr(flag) )              return false;
   n_pass_LAr++;
-  if( !passBadJet(flag) )           return false;
+  if( !SusyNtTools::passBadJet(flag) )           return false;
   n_pass_BadJet++;
-  if( !passBadMuon(flag) )          return false;
+  if( !SusyNtTools::passBadMuon(flag) )          return false;
   n_pass_BadMuon++;
-  if( !passCosmic(flag) )           return false;
+  if( !SusyNtTools::passCosmic(flag) )           return false;
   n_pass_Cosmic++;
   if(!passNBaseLepCut(baseLeps))    return false;
   
@@ -231,7 +231,7 @@ bool Susy2LepCutflow::passSR3(const LeptonVector& leptons, const JetVector& jets
   n_pass_SR3bjv[m_ET]++;
 
   // Veto top-tag events 
-  if( !passTopTag(leptons,jets,met) )    return false;
+  if( !m_nttools.passTopTag(leptons,jets,met) )    return false;
   n_pass_SR3mct[m_ET]++;
 
   // MetRel > 50
@@ -409,7 +409,7 @@ bool Susy2LepCutflow::passbJetVeto(const JetVector& jets)
   for(uint i=0; i<jets.size(); ++i){
     const Jet* jet = jets.at(i);
     if( jet->combNN < -1.25    ) continue;
-    SusyNtTools::bTagSF(nt.evt(), jets, nt.evt()->mcChannel, BTag_NOM); // just to test the btag tool
+    m_nttools.bTagSF(nt.evt(), jets, nt.evt()->mcChannel, BTag_NOM); // just to test the btag tool
     hasbjet = true;
     break;
   }
@@ -435,7 +435,7 @@ bool Susy2LepCutflow::passZVeto(const LeptonVector& leptons, float Zlow, float Z
 bool Susy2LepCutflow::passMETRel(const Met *met, const LeptonVector& leptons, 
 				 const JetVector& jets, float metMax){
   
-  if( getMetRel(met,leptons,jets) < metMax ) return false;
+  if( m_nttools.getMetRel(met,leptons,jets) < metMax ) return false;
   return true;
 }
 /*--------------------------------------------------------------------------------*/
@@ -446,7 +446,7 @@ bool Susy2LepCutflow::passdPhi(TLorentzVector v0, TLorentzVector v1, float cut)
 /*--------------------------------------------------------------------------------*/
 bool Susy2LepCutflow::passMT2(const LeptonVector& leptons, const Met* met, float cut)
 {
-  float mT2 = getMT2(leptons, met);
+  float mT2 = m_nttools.getMT2(leptons, met);
   return (mT2 > cut);
 }
 

--- a/Root/Susy3LepCutflow.cxx
+++ b/Root/Susy3LepCutflow.cxx
@@ -156,7 +156,7 @@ Bool_t Susy3LepCutflow::Process(Long64_t entry)
 
   // Apply btag efficiency correction if selecting on b-jets
   bool applyBTagSF = m_vetoB;
-  float btagSF = applyBTagSF? bTagSF(evt, m_signalJets, evt->mcChannel) : 1;
+  float btagSF = applyBTagSF? nttools().bTagSF(evt, m_signalJets, evt->mcChannel) : 1;
 
   // Full event weight
   float fullWeight = w * lepSF * tauSF * btagSF;
@@ -221,15 +221,15 @@ bool Susy3LepCutflow::selectEvent(const LeptonVector& leptons, const TauVector& 
   int flag = cleaningCutFlags();
 
   // Cleaning cuts
-  if(!passHotSpot(flag)) return false;
+  if(!nttools().passHotSpot(flag)) return false;
   n_pass_hotSpot++;
-  if(!passBadJet(flag)) return false;
+  if(!nttools().passBadJet(flag)) return false;
   n_pass_badJet++;
-  if(!passBadMuon(flag)) return false;
+  if(!nttools().passBadMuon(flag)) return false;
   n_pass_badMuon++;
-  if(!passCosmic(flag)) return false;
+  if(!nttools().passCosmic(flag)) return false;
   n_pass_cosmic++;
-  if(!passDeadRegions(m_preJets, met, evt->run, evt->isMC)) return false;
+  if(!nttools().passDeadRegions(m_preJets, met, evt->run, evt->isMC)) return false;
   n_pass_feb++;
   if(!passNLepCut(leptons)) return false;
   n_pass_nLep++;
@@ -278,7 +278,7 @@ void Susy3LepCutflow::finalizeHistos()
 bool Susy3LepCutflow::passFCal()
 {
   const Event* evt = nt.evt();
-  if(hasJetInBadFCAL(m_baseJets, evt->run, evt->isMC)) return false;
+  if(nttools().hasJetInBadFCAL(m_baseJets, evt->run, evt->isMC)) return false;
   return true;
 }
 /*--------------------------------------------------------------------------------*/
@@ -306,7 +306,7 @@ bool Susy3LepCutflow::passTrigger(const LeptonVector& leptons)
 /*--------------------------------------------------------------------------------*/
 bool Susy3LepCutflow::passSFOSCut(const LeptonVector& leptons)
 {
-  bool sfos = hasSFOS(leptons);
+  bool sfos = nttools().hasSFOS(leptons);
   if(m_vetoSFOS   &&  sfos) return false;
   if(m_selectSFOS && !sfos) return false;
   return true;
@@ -321,7 +321,7 @@ bool Susy3LepCutflow::passMetCut(const Met* met)
 /*--------------------------------------------------------------------------------*/
 bool Susy3LepCutflow::passZCut(const LeptonVector& leptons)
 {
-  bool hasz = hasZ(leptons);
+  bool hasz = nttools().hasZ(leptons);
   if( m_vetoZ   &&  hasz ) return false;
   if( m_selectZ && !hasz ) return false;
   return true;
@@ -329,7 +329,7 @@ bool Susy3LepCutflow::passZCut(const LeptonVector& leptons)
 /*--------------------------------------------------------------------------------*/
 bool Susy3LepCutflow::passBJetCut( )
 {
-  bool hasB = hasBJet(m_signalJets);
+  bool hasB = nttools().hasBJet(m_signalJets);
   if( m_vetoB   &&  hasB ) return false;
   if( m_selectB && !hasB ) return false;
   return true;
@@ -341,10 +341,10 @@ bool Susy3LepCutflow::passMtCut(const LeptonVector& leptons, const Met* met)
   if(m_mtMin > 0)
   {
     uint zl1, zl2;
-    if(findBestZ(zl1, zl2, leptons)){
+    if(nttools().findBestZ(zl1, zl2, leptons)){
       for(uint iL=0; iL<leptons.size(); iL++) {
         if(iL!=zl1 && iL!=zl2) {
-          if( Mt(leptons[iL],met) < m_mtMin ) return false;
+          if( nttools().Mt(leptons[iL],met) < m_mtMin ) return false;
         }
       }
     }

--- a/Root/SusyNtAna.cxx
+++ b/Root/SusyNtAna.cxx
@@ -9,7 +9,6 @@ using namespace Susy;
 // SusyNtAna Constructor
 /*--------------------------------------------------------------------------------*/
 SusyNtAna::SusyNtAna() : 
-        SusyNtTools(),
         nt(m_entry),
         m_entry(0),
         m_selectTaus(true),
@@ -172,8 +171,8 @@ bool SusyNtAna::isDuplicate(unsigned int run, unsigned int event){
 float SusyNtAna::getEventWeight(float lumi, bool useSumwMap, bool useProcSumw,
                                 bool useSusyXsec, MCWeighter::WeightSys sys)
 {
-  return SusyNtTools::getEventWeight(nt.evt(), lumi, useSumwMap, &m_sumwMap, 
-                                     useProcSumw, useSusyXsec, sys);
+    return m_nttools.getEventWeight(nt.evt(), lumi, useSumwMap, &m_sumwMap,
+                                    useProcSumw, useSusyXsec, sys);
 }
 /*--------------------------------------------------------------------------------*/
 /*float SusyNtAna::getEventWeightFixed(unsigned int mcChannel, float lumi)
@@ -221,28 +220,28 @@ void SusyNtAna::selectObjects(SusyNtSys sys, bool removeLepsFromIso,
   clearObjects();
 
   // Get the Baseline objets
-  getBaselineObjects(&nt, m_preElectrons, m_preMuons, m_preJets, 
-                     m_baseElectrons, m_baseMuons, m_baseTaus, m_baseJets, 
-                     sys, m_selectTaus, n0150BugFix);
+  m_nttools.getBaselineObjects(&nt, m_preElectrons, m_preMuons, m_preJets,
+                               m_baseElectrons, m_baseMuons, m_baseTaus, m_baseJets,
+                               sys, m_selectTaus, n0150BugFix);
 
   // Now grab Signal objects
   // New signal tau prescription, fill both ID levels at once
-  getSignalObjects(m_baseElectrons, m_baseMuons, m_baseTaus, m_baseJets,
-                   m_signalElectrons, m_signalMuons, 
-                   m_mediumTaus, m_tightTaus, 
-                   m_signalJets, m_signalJets2Lep, 
-                   nt.evt()->nVtx, nt.evt()->isMC, 
-                   removeLepsFromIso, sys);
+  m_nttools.getSignalObjects(m_baseElectrons, m_baseMuons, m_baseTaus, m_baseJets,
+                             m_signalElectrons, m_signalMuons,
+                             m_mediumTaus, m_tightTaus,
+                             m_signalJets, m_signalJets2Lep,
+                             nt.evt()->nVtx, nt.evt()->isMC,
+                             removeLepsFromIso, sys);
   m_signalTaus = signalTauID==TauID_tight? m_tightTaus : m_mediumTaus;
 
   // Grab met
   SusyNtSys metSys = sys;
   if(sys==NtSys_JVF_UP || sys==NtSys_JVF_DN) metSys = NtSys_NOM;
-  m_met = getMet(&nt, metSys);
+  m_met = m_nttools.getMet(&nt, metSys);
 
   // Build Lepton vectors
-  buildLeptons(m_baseLeptons, m_baseElectrons, m_baseMuons);
-  buildLeptons(m_signalLeptons, m_signalElectrons, m_signalMuons);
+  m_nttools.buildLeptons(m_baseLeptons, m_baseElectrons, m_baseMuons);
+  m_nttools.buildLeptons(m_signalLeptons, m_signalElectrons, m_signalMuons);
 
   // sort leptons by pt
   std::sort(m_baseLeptons.begin(), m_baseLeptons.end(), comparePt);
@@ -255,9 +254,9 @@ void SusyNtAna::selectObjects(SusyNtSys sys, bool removeLepsFromIso,
 /*--------------------------------------------------------------------------------*/
 int SusyNtAna::cleaningCutFlags()
 {
-  return SusyNtTools::cleaningCutFlags(nt.evt()->cutFlags[NtSys_NOM],
-                                       m_preMuons, m_baseMuons,
-                                       m_preJets, m_baseJets);
+  return m_nttools.cleaningCutFlags(nt.evt()->cutFlags[NtSys_NOM],
+                                    m_preMuons, m_baseMuons,
+                                    m_preJets, m_baseJets);
 }
 
 
@@ -432,5 +431,5 @@ void SusyNtAna::dumpSignalJets()
 /*--------------------------------------------------------------------------------*/
 void SusyNtAna::buildSumwMap(TChain* chain)
 {
-  m_sumwMap = SusyNtTools::buildSumwMap(chain);
+  m_sumwMap = m_nttools.buildSumwMap(chain);
 }

--- a/Root/SusyNtTools.cxx
+++ b/Root/SusyNtTools.cxx
@@ -768,33 +768,14 @@ float SusyNtTools::muEtConeCorr(const Muon* mu,
 int SusyNtTools::numberOfCLJets(const JetVector& jets, JVFUncertaintyTool* jvfTool,
                                 SusyNtSys sys, AnalysisType anaType)
 {
-  int ans = 0;
-
-  for(uint ij=0; ij<jets.size(); ++ij){
-    const Jet* j = jets.at(ij);
-    if(JetSelector(jvfTool, sys, anaType).isCentralLightJet(j)){
-      ans++;
-    }
-  }
-
-  return ans;
+    return JetSelector(jvfTool, sys, anaType).count_CL_jets(jets);
 }
-
 /*--------------------------------------------------------------------------------*/
 // Count Number of 2 Lepton B Jets
 /*--------------------------------------------------------------------------------*/
 int SusyNtTools::numberOfCBJets(const JetVector& jets)
 {
-  int ans = 0;
-
-  for(uint ij=0; ij<jets.size(); ++ij){
-    const Jet* j = jets.at(ij);
-    if(JetSelector::isCentralBJet(j)){
-      ans++;
-    }
-  }
-
-  return ans;
+    return JetSelector::count_CB_jets(jets);
 }
 
 /*--------------------------------------------------------------------------------*/
@@ -802,16 +783,7 @@ int SusyNtTools::numberOfCBJets(const JetVector& jets)
 /*--------------------------------------------------------------------------------*/
 int SusyNtTools::numberOfFJets(const JetVector& jets)
 {
-  int ans = 0;
-
-  for(uint ij=0; ij<jets.size(); ++ij){
-    const Jet* j = jets.at(ij);
-    if(JetSelector::isForwardJet(j)){
-      ans++;
-    }
-  }
-
-  return ans;
+    return JetSelector::count_F_jets(jets);
 }
 
 /*--------------------------------------------------------------------------------*/

--- a/Root/SusyNtTools.cxx
+++ b/Root/SusyNtTools.cxx
@@ -30,8 +30,7 @@ SusyNtTools::SusyNtTools() :
         m_doIPCut(true)
 	//m_btagTool(NULL)
 {
-  m_jvfTool = new JVFUncertaintyTool();
-  m_jvfTool->UseGeV(true);
+    m_jvfTool = JetSelector::build_jvf_tool();
 }
 
 /*--------------------------------------------------------------------------------*/

--- a/SusyNtuple/JetSelector.h
+++ b/SusyNtuple/JetSelector.h
@@ -37,6 +37,8 @@ public:
     static JetSelector build_3L_analysis_selector(JVFUncertaintyTool* const, const SusyNtSys&, const AnalysisType&);
     /// jet selection used for the WH study
     static JetSelector build_WH_analysis_selector(JVFUncertaintyTool* const, const SusyNtSys&, const AnalysisType&);
+    /// build a jvf tool; the user is responsible for its deletion
+    static JVFUncertaintyTool* build_jvf_tool();
 /*
   \todo: these will be used internally when refactoring
 

--- a/SusyNtuple/JetSelector.h
+++ b/SusyNtuple/JetSelector.h
@@ -1,0 +1,106 @@
+//  -*- c++ -*-
+#ifndef SUSY_JETSELECTOR_H
+#define SUSY_JETSELECTOR_H
+
+#include "SusyNtuple/SusyDefs.h"
+
+class JVFUncertaintyTool;
+
+namespace Susy {
+///  A class to select jets
+/**
+   Each analysis has slightly different jet requirements.  This class
+   tries to provide a centralized place where such requirements are
+   defined.
+
+   The user should call build_*analysis_selector (rather than using
+   the default constructor).
+
+   See test_JetSelector.cxx for an example of how this class can be used
+
+   Note to self:
+   design choices tested in https://gist.github.com/gerbaudo/7854402
+
+   davide.gerbaudo@gmail.com, Aug 2014
+*/
+
+class Jet;
+
+class JetSelector
+{
+public:
+    /// dummy c'tor; prefer analysis-specific build_*_selector methods
+    JetSelector(JVFUncertaintyTool* const jvftool, const SusyNtSys& systematic, const AnalysisType& analysis);
+    /// jet selection used for the two-lepton study
+    static JetSelector build_2L_analysis_selector(JVFUncertaintyTool* const, const SusyNtSys&, const AnalysisType&);
+    /// jet selection used for the three-lepton study
+    static JetSelector build_3L_analysis_selector(JVFUncertaintyTool* const, const SusyNtSys&, const AnalysisType&);
+    /// jet selection used for the WH study
+    static JetSelector build_WH_analysis_selector(JVFUncertaintyTool* const, const SusyNtSys&, const AnalysisType&);
+/*
+  \todo: these will be used internally when refactoring
+
+    bool isCentral(const Jet &j) { return fabs(j.detEta)<m_max_eta; }
+    bool isCentralLight(const Jet &j) const { return true; }
+    bool isCentralB(const Jet &j) const { return true; }
+    bool isJvfConfirmed(const Jet &j) const { return true; }
+    float minPt() const { return m_min_pt; }
+    float maxEta() const { return m_max_eta; }
+    JetSelector& requireMinPt(float v) { m_min_pt = v; return *this; }
+    JetSelector& requireMaxEta(float v) { m_max_eta = v; return *this; }
+*/
+    // todo:
+    // - make them const
+    bool isSignalJet(const Jet* jet);
+    bool isSignalJet2Lep(const Jet* jet);
+    bool isCentralLightJet(const Jet* jet);
+    static bool isCentralBJet(const Jet* jet);
+    static bool isForwardJet(const Jet* jet);
+    bool isBadFCALJet(const Jet* jet);
+    bool hasJetInBadFCAL(const JetVector& baseJets, uint run, bool isMC);
+
+    bool selects(const Jet* j) const { return false; } ///< placeholder
+    bool verbose() const { return m_verbose; }
+    JetSelector& setVerbose(bool v) { m_verbose = v; return *this; }
+
+    bool jetPassesJvfRequirement(const Jet* jet, float maxPt, float maxEta, float nominalJvtThres);
+
+
+private:
+    /*
+  \todo: these will be used internally when refactoring
+    bool m_skip_pt;
+    bool m_skip_eta;
+    bool m_skip_jvf;
+    float m_min_pt; ///< do not consider jets with pt below this value
+    float m_max_eta; ///< do not consider jets with eta above this value
+    float m_max_jvf_eta; ///< above this eta we cannot apply the JVF requirement
+    float m_min_jvf; ///< below this value a jet is not JVF-confirmed
+    */
+    JVFUncertaintyTool* const m_jvftool; ///< jvf tool (note weird design --> weird const-ness)
+    SusyNtSys m_systematic; ///< current syst variation
+    AnalysisType m_analysis; ///< analysis
+    bool m_verbose; ///< toggle verbose messages
+};
+//----------------------------------------------------------
+/// wrapper functor to be used with std algorithms
+/**
+   Note to self: in order for this to be a well-behaved functor,
+   I can only provide one operator()(const Lepton *l), and not
+           (const Lepton *l) + (const Lepton &l).
+   Otherwise I won't be able to use the std function adapters (namely
+   not1). See Item 40 of S.Meyer's "Effective STL".
+*/
+class JetSelectorFunctor : public std::unary_function<const Jet*, bool>
+{
+public:
+    JetSelectorFunctor(const JetSelector &js): m_selector(js) {};
+    bool operator() (const Jet *j) const { return m_selector.selects(j); }
+private:
+    const JetSelector &m_selector;
+};
+//----------------------------------------------------------
+
+} // Susy
+
+#endif

--- a/SusyNtuple/JetSelector.h
+++ b/SusyNtuple/JetSelector.h
@@ -67,6 +67,12 @@ public:
 
     bool jetPassesJvfRequirement(const Jet* jet, float maxPt, float maxEta, float nominalJvtThres);
 
+    /// count central light jets \todo const (depends on jvf tool interface)
+    size_t count_CL_jets(const JetVector &jets) /*const*/;
+    /// count central b-tagged jets \todo const
+    static size_t count_CB_jets(const JetVector &jets) /*const*/;
+    /// count forward jets \todo const
+    static size_t count_F_jets(const JetVector &jets) /*const*/;
 
 private:
     /*

--- a/SusyNtuple/SusyNtAna.h
+++ b/SusyNtuple/SusyNtAna.h
@@ -22,7 +22,7 @@ typedef std::map< unsigned int, std::set<unsigned int>* > RunEventMap;
 
 
 ///    SusyNtAna - base class for analyzing SusyNt
-class SusyNtAna : public TSelector, public SusyNtTools
+class SusyNtAna : public TSelector
 {
 
   public:
@@ -33,7 +33,10 @@ class SusyNtAna : public TSelector, public SusyNtTools
 
     /// SusyNt object, access to the SusyNt variables
     Susy::SusyNtObject nt;
-
+    /// helper tools and functions
+    SusyNtTools m_nttools;
+    inline void setAnaType(AnalysisType v){ m_nttools.setAnaType(v); }
+    /*const*/ SusyNtTools& nttools() /*const*/ { return m_nttools; } // DG should be const
 
     //
     // TSelector methods

--- a/SusyNtuple/SusyNtTools.h
+++ b/SusyNtuple/SusyNtTools.h
@@ -139,8 +139,6 @@ class SusyNtTools
                      TauID tauEleID=TauID_loose, TauID tauMuoID=TauID_medium);
     bool isSemiSignalElectron(const Susy::Electron* ele);
     bool isSemiSignalMuon(const Susy::Muon* mu);
-    bool isSignalJet(const Susy::Jet* jet, SusyNtSys sys=NtSys_NOM);
-    bool isSignalJet2Lep(const Susy::Jet* jet, SusyNtSys sys=NtSys_NOM);
 
 
     /// Build Lepton vector - we should probably sort them here
@@ -355,10 +353,6 @@ class SusyNtTools
     static JetVector getBTagSFJets2Lep(const JetVector& baseJets);
     float bTagSF(const Susy::Event*, const JetVector& jets, int mcID, BTagSys sys=BTag_NOM);
 
-    // 2 Lepton jet methods and counters
-    static bool isCentralLightJet(const Susy::Jet* jet, JVFUncertaintyTool* jvfTool, SusyNtSys sys, AnalysisType anaType);
-    static bool isCentralBJet    (const Susy::Jet* jet);
-    static bool isForwardJet     (const Susy::Jet* jet);
 
     static int numberOfCLJets    (const JetVector& jets, JVFUncertaintyTool* jvfTool, SusyNtSys sys, AnalysisType anaType);
     static int numberOfCBJets    (const JetVector& jets);

--- a/SusyNtuple/SusyNtTools.h
+++ b/SusyNtuple/SusyNtTools.h
@@ -208,25 +208,25 @@ class SusyNtTools
     //
   
     /// No electron or jet in the LAr hole - shouldn't be used anymore
-    bool passLAr(int flag)     { return true; }
+    static bool passLAr(int flag)     { return true; }
 
     /// Pass Tile hot spot veto
-    bool passHotSpot(int flag) { return ( flag & ECut_HotSpot ); }
+    static bool passHotSpot(int flag) { return ( flag & ECut_HotSpot ); }
   
     /// Pass the Bad Jet requirement
-    bool passBadJet(int flag)  { return ( flag & ECut_BadJet );  }
+    static bool passBadJet(int flag)  { return ( flag & ECut_BadJet );  }
     
     /// Pass the Bad Muon requirement
-    bool passBadMuon(int flag) { return ( flag & ECut_BadMuon ); }
+    static bool passBadMuon(int flag) { return ( flag & ECut_BadMuon ); }
     
     /// No cosmic muons
-    bool passCosmic(int flag)  { return ( flag & ECut_Cosmic );  }
+    static bool passCosmic(int flag)  { return ( flag & ECut_Cosmic );  }
     
     /// Pass Smart Veto
-    bool passSmartVeto(int flag) { return (flag & ECut_SmartVeto); }
+    static bool passSmartVeto(int flag) { return (flag & ECut_SmartVeto); }
 
     /// Pass All the above, incase you don't care about cut flow
-    bool passAll(int flag)
+    static bool passAll(int flag)
     { 
       int mask = ECut_HotSpot || ECut_BadJet || ECut_BadMuon || ECut_Cosmic || ECut_SmartVeto;
       return (flag & mask) == mask;
@@ -238,22 +238,22 @@ class SusyNtTools
     // NOTE: Filtering on by default!
     
     /// pass GRL
-    bool passGRL(int flag)         { return (flag & ECut_GRL);      }
+    static bool passGRL(int flag)         { return (flag & ECut_GRL);      }
 
     /// pass LArErr
-    bool passLarErr(int flag)      { return (flag & ECut_LarErr);   }
+    static bool passLarErr(int flag)      { return (flag & ECut_LarErr);   }
     
     /// pass Tile Err
-    bool passTileErr(int flag)     { return (flag & ECut_TileErr);  }
+    static bool passTileErr(int flag)     { return (flag & ECut_TileErr);  }
 
     /// Pass TTC veto
-    bool passTTCVeto(int flag)     { return (flag & ECut_TTC);      }
+    static bool passTTCVeto(int flag)     { return (flag & ECut_TTC);      }
 
     /// pass primary vertex
-    bool passGoodVtx(int flag)     { return (flag & ECut_GoodVtx);  }
+    static bool passGoodVtx(int flag)     { return (flag & ECut_GoodVtx);  }
 
     /// pass tile trip cut
-    bool passTileTripCut(int flag) { return (flag & ECut_TileTrip); }
+    static bool passTileTripCut(int flag) { return (flag & ECut_TileTrip); }
 
     /// look at the MC truth record and determine whether SUSY propagators were involved
     static bool eventHasSusyPropagators(const std::vector< int > &pdgs,


### PR DESCRIPTION
This is a first try at trying to get out of the inheritance
`SusyNtAna : SusyNtTools`.
This pull request is not complete yet, but rather a place where
we can discuss whether this is a sensible approach.

These are the reasons why I think we should go in this direction:
- the inheritance `Susy2LepCutflow : SusyNtAna : SusyNtTools`
hides many of the functions and attributes. For example, we often
access in `Susy2LepCutflow` functions and attributes that are nested
two levels down. I found this hard to follow (often not sure where the
function is being declared)
- we got burnt a couple of times with the attribute `m_anaType`
not being propagated correctly within the constructor
- logically `SusyNtAna` is not a `SusyNtTools`

This change will break many things downstream (see for example
`Susy2LepCutflow`). Comments and suggestions are welcome.