### PR TITLE
add eventNumber alias

### DIFF
--- a/SusyNtuple/Event.h
+++ b/SusyNtuple/Event.h
@@ -24,6 +24,7 @@ public:
 
     unsigned int run;         ///< run number
     unsigned int event;       ///< event number
+    inline unsigned int eventNumber() const { return event; } ///< alias for event; TTree::Draw doesn't like event.event
     unsigned int lb;          ///< lumi block number
     DataStream stream;        ///< DataStream enum, defined in SusyDefs.h
 
@@ -118,7 +119,7 @@ public:
       eventScale = alphaQCD = alphaQED = 0;
     }
 
-    ClassDef(Event, 28);
+    ClassDef(Event, 29);
   };
 } // Susy
 #endif


### PR DESCRIPTION
A single-commit pull, just to document the bug.

This method should be used instead of event.event when trying to
access this leaf from TTree::Scan or TTree::Draw.
Root does not like event.event. Don't know whether this is specific
to root6 (we had this branch name already before...).

This is how the bug shows up:
```
root -l susyNt.root
root [1] susyNt->Scan("event.run:event.event")
************************************
*    Row   * event.run * event.eve *
************************************
*        0 *    212272 *         0 *
*        1 *    212272 *         0 *
*        2 *    212272 *         0 *
```
and this is how it's fixed
```
root [2] gROOT->ProcessLine(".x ${ROOTCOREDIR}/scripts/load_packages.C")
Info in <xAOD::Init>: Environment initialised for data access
(Long_t) 0
root [3] susyNt->Scan("event.run:event.eventNumber()")
************************************
*    Row   * event.run * event.eve *
************************************
*        0 *    212272 *   8180301 *
*        1 *    212272 *   8180302 *
*        2 *    212272 *   8180303 *
```
